### PR TITLE
docs(core): fix typo in annotations documentation

### DIFF
--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -456,7 +456,7 @@ export class Directive extends Injectable {
  * - loads the selected template into the shadow DOM.
  * - creates a child [Injector] which is configured with the [Component.services].
  *
- * All template expressions and statments are then evaluted against the component instance.
+ * All template expressions and statements are then evaluted against the component instance.
  *
  * For details on the `@Template` annotation, see [Template].
  *


### PR DESCRIPTION
This PR fixes a minor typo in one of the documentation comments in `core/annotations/annotations.js`.

No tests or code are affected.
